### PR TITLE
Export DividerWidget and document its purpose

### DIFF
--- a/lib/multi_split_view.dart
+++ b/lib/multi_split_view.dart
@@ -4,6 +4,7 @@ export 'src/area.dart';
 export 'src/controller.dart';
 export 'src/divider_painter.dart';
 export 'src/divider_tap_typedefs.dart';
+export 'src/divider_widget.dart';
 export 'src/multi_split_view.dart';
 export 'src/theme_data.dart';
 export 'src/theme_widget.dart';

--- a/lib/src/divider_widget.dart
+++ b/lib/src/divider_widget.dart
@@ -1,10 +1,14 @@
 import 'package:flutter/widgets.dart';
-import 'package:meta/meta.dart';
 import 'package:multi_split_view/src/divider_painter.dart';
 import 'package:multi_split_view/src/theme_data.dart';
 
-/// The divider widget.
-@internal
+/// The standard divider widget for [MultiSplitView] that renders
+/// the [DividerPainter] from the current [MultiSplitViewTheme].
+///
+/// Useful to use in conjunction with [MultiSplitView.dividerBuilder]
+/// if you still want to use the theme's [DividerPainter] but want to
+/// further customize the divider widget (e.g., surround with a
+/// tooltip widget).
 class DividerWidget extends StatefulWidget {
   const DividerWidget(
       {required this.axis,

--- a/lib/src/multi_split_view.dart
+++ b/lib/src/multi_split_view.dart
@@ -5,7 +5,7 @@ import 'package:flutter/widgets.dart';
 import 'package:multi_split_view/src/area.dart';
 import 'package:multi_split_view/src/controller.dart';
 import 'package:multi_split_view/src/divider_tap_typedefs.dart';
-import 'package:multi_split_view/src/internal/divider_widget.dart';
+import 'package:multi_split_view/src/divider_widget.dart';
 import 'package:multi_split_view/src/internal/initial_drag.dart';
 import 'package:multi_split_view/src/internal/sizes_cache.dart';
 import 'package:multi_split_view/src/theme_data.dart';


### PR DESCRIPTION
Hi @caduandrade see what you think, this could close #40. This mod allowed me to easily add a tooltip for the divider while still using the theme divider painter.

This package is brilliant thank you for contributing this to the community!