### PR TITLE
Issue with the copyWith Function in the Area Class

### DIFF
--- a/lib/src/area.dart
+++ b/lib/src/area.dart
@@ -98,22 +98,29 @@ class Area {
 
   /// Creates a copy of this [Area] with the given fields replaced with their.
   Area copyWith({
-    dynamic id,
-    double? size,
-    double? flex,
-    double? min,
-    double? max,
-    dynamic data,
-    AreaWidgetBuilder? builder,
+    dynamic Function()? id,
+    double? Function()? size,
+    double? Function()? flex,
+    double? Function()? min,
+    double? Function()? max,
+    dynamic Function()? data,
+    AreaWidgetBuilder? Function()? builder,
   }) {
+    final hasPassedSize = size != null;
+    final hasPassedFlex = flex != null;
+
+    if (hasPassedSize && hasPassedFlex) {
+      throw ArgumentError('Cannot provide both a size and a flex.');
+    }
+
     return Area(
-      id: id ?? this.id,
-      size: size == null && flex == null ? this.size : size,
-      flex: size == null && flex == null ? this.flex : flex,
-      min: min ?? this.min,
-      max: max ?? this.max,
-      data: data ?? this.data,
-      builder: builder ?? this.builder,
+      id: id == null ? this.id : id(),
+      size: hasPassedFlex ? null : (hasPassedSize ? size!() : this.size),
+      flex: hasPassedSize ? null : (hasPassedFlex ? flex!() : this.flex),
+      min: min == null ? this.min : min(),
+      max: max == null ? this.max : max(),
+      data: data == null ? this.data : data(),
+      builder: builder == null ? this.builder : builder(),
     );
   }
 }

--- a/test/area_copy_with_test.dart
+++ b/test/area_copy_with_test.dart
@@ -7,7 +7,7 @@ void main() {
       test('flex and size', () {
         Area area = Area(size: 2);
         expect(() {
-          area.copyWith(size: 1, flex: 2);
+          area.copyWith(size: () => 1, flex: () => 2);
         },
             throwsA(isA<ArgumentError>().having((e) => e.message, '',
                 'Cannot provide both a size and a flex.')));
@@ -15,30 +15,30 @@ void main() {
       test('negative size', () {
         Area area = Area(size: 2);
         expect(() {
-          area.copyWith(size: -1);
+          area.copyWith(size: () => -1);
         }, throwsA(isA<ArgumentError>().having((e) => e.name, '', 'size')));
       });
       test('negative flex', () {
         Area area = Area(flex: 2);
         expect(() {
-          area.copyWith(flex: -1);
+          area.copyWith(flex: () => -1);
         }, throwsA(isA<ArgumentError>().having((e) => e.name, '', 'flex')));
       });
       test('negative min', () {
         Area area = Area();
         expect(() {
-          area.copyWith(min: -1);
+          area.copyWith(min: () => -1);
         }, throwsA(isA<ArgumentError>().having((e) => e.name, '', 'min')));
       });
       test('negative max', () {
         Area area = Area();
         expect(() {
-          area.copyWith(max: -1);
+          area.copyWith(max: () => -1);
         }, throwsA(isA<ArgumentError>().having((e) => e.name, '', 'max')));
       });
       test('flex', () {
         Area area = Area();
-        area = area.copyWith(flex: 2);
+        area = area.copyWith(flex: () => 2);
         expect(area.size, null);
         expect(area.flex, 2);
         expect(area.max, null);
@@ -47,7 +47,7 @@ void main() {
       });
       test('size', () {
         Area area = Area(size: 2);
-        area = area.copyWith(size: 3);
+        area = area.copyWith(size: () => 3);
         expect(area.size, 3);
         expect(area.flex, null);
         expect(area.max, null);
@@ -59,7 +59,7 @@ void main() {
         expect(area.flex, 3);
         expect(area.min, 3);
 
-        area = area.copyWith(min: 1);
+        area = area.copyWith(min: () => 1);
         expect(area.size, null);
         expect(area.flex, 3);
         expect(area.max, null);
@@ -71,7 +71,7 @@ void main() {
         expect(area.flex, 2);
         expect(area.max, 2);
 
-        area = area.copyWith(max: 10);
+        area = area.copyWith(max: () => 10);
         expect(area.size, null);
         expect(area.flex, 2);
         expect(area.max, 10);
@@ -83,7 +83,7 @@ void main() {
         expect(area.size, 3);
         expect(area.min, 3);
 
-        area = area.copyWith(min: 3);
+        area = area.copyWith(min: () => 3);
         expect(area.size, 3);
         expect(area.flex, null);
         expect(area.max, null);
@@ -95,7 +95,7 @@ void main() {
         expect(area.size, 2);
         expect(area.max, 2);
 
-        area = area.copyWith(max: 10);
+        area = area.copyWith(max: () => 10);
         expect(area.size, 2);
         expect(area.flex, null);
         expect(area.max, 10);
@@ -105,7 +105,7 @@ void main() {
       test('flex to size', () {
         Area area = Area();
 
-        area = area.copyWith(size: 1);
+        area = area.copyWith(size: () => 1);
 
         expect(area.size, 1);
         expect(area.flex, null);
@@ -116,7 +116,7 @@ void main() {
       test('size to flex', () {
         Area area = Area(size: 10);
 
-        area = area.copyWith(flex: 2);
+        area = area.copyWith(flex: () => 2);
 
         expect(area.size, null);
         expect(area.flex, 2);
@@ -126,7 +126,7 @@ void main() {
       });
       test('same id', () {
         Area area1 = Area(id: 'id');
-        Area area2 = area1.copyWith(flex: 2);
+        Area area2 = area1.copyWith(flex: () => 2);
 
         expect(area1.id, isNotNull);
         expect(area2.id, isNotNull);
@@ -136,7 +136,7 @@ void main() {
       });
       test('change id', () {
         Area area1 = Area();
-        Area area2 = area1.copyWith(id: 'id');
+        Area area2 = area1.copyWith(id: () => 'id');
 
         expect(area1.id, isNotNull);
         expect(area2.id, isNotNull);


### PR DESCRIPTION
## Issue with the copyWith Function in the Area Class
The current implementation of the copyWith function in the Area class is flawed. Specifically, it does not handle null values correctly when passed as parameters.

### Problem Description
The current copyWith function in the Area class does not allow null values to be used as arguments. This limitation is problematic because it restricts the flexibility of the function, making it less useful in scenarios where null might be a legitimate value to signify the absence of data or the need to reset a property.

### Importance of Handling null Values
In many programming scenarios, the ability to pass null as a parameter is crucial. This functionality is commonly required to reset or clear a property value within a class. By allowing null values, the copyWith function can provide more comprehensive and versatile behavior, aligning with common programming practices and user expectations.

### Reference
For more information and a potential solution, you can refer to the discussion on [Stack Overflow](https://stackoverflow.com/questions/68009392/dart-custom-copywith-method-with-nullable-properties). This discussion provides insights into implementing a copyWith method that can handle nullable properties effectively.

By addressing this issue, the copyWith function in the Area class can be made more robust and adaptable, thereby improving the overall utility and reliability of the class.