### PR TITLE
Adjust dependency version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,9 +24,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.15.0
+  meta: ^1.12.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^6.0.0
+  flutter_lints: ^4.0.0


### PR DESCRIPTION
I noticed on pub.dev that the Min Dart SDK is 2.14, but I couldn't run it on SDK versions higher than this. I found that the lint and meta versions were too high, so I adjusted them. After this adjustment, this library can run in more versions of Flutter applications.